### PR TITLE
Export correct public key.

### DIFF
--- a/android/src/main/kotlin/xyz/metaman/hardware_crypto/HardwareCrypto.kt
+++ b/android/src/main/kotlin/xyz/metaman/hardware_crypto/HardwareCrypto.kt
@@ -234,8 +234,7 @@ class HardwareCrypto(private val activityBinding: ActivityPluginBinding) {
 
         kpg.initialize(parameterSpec)
         val kp = kpg.generateKeyPair()
-        val pubKey = kp.getPublic()
-        pubKeyBytes = pubKey.getEncoded()
+        pubKeyBytes = kp.public.encoded
 
         val entry = keyStore.getEntry(alias, null) as KeyStore.PrivateKeyEntry
         val factory = KeyFactory.getInstance(KeyProperties.KEY_ALGORITHM_EC, "AndroidKeyStore")


### PR DESCRIPTION
This exports the public key from the key generated in hardware instead of the public key for certificate that signed the private key.